### PR TITLE
feat: Support entities with multiple types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 test/resources/testPage.html
 test/resources/microdata4.html
 coverage/
+CHANGELOG.md

--- a/src/parsers/jsonld-parser.js
+++ b/src/parsers/jsonld-parser.js
@@ -129,9 +129,16 @@ export default class JsonldParser {
               return;
             }
 
-            normalizedData[graphItem['@type']] =
-              normalizedData[graphItem['@type']] || [];
-            normalizedData[graphItem['@type']].push(graphItem);
+            if (Array.isArray(graphItem['@type'])) {
+              graphItem['@type'].forEach((type) => {
+                normalizedData[type] = normalizedData[type] || [];
+                normalizedData[type].push(graphItem);
+              });
+            } else {
+              normalizedData[graphItem['@type']] =
+                normalizedData[graphItem['@type']] || [];
+              normalizedData[graphItem['@type']].push(graphItem);
+            }
           });
         } else {
           if (!item['@type']) {
@@ -139,8 +146,15 @@ export default class JsonldParser {
             return;
           }
 
-          normalizedData[item['@type']] = normalizedData[item['@type']] || [];
-          normalizedData[item['@type']].push(item);
+          if (Array.isArray(item['@type'])) {
+            item['@type'].forEach((type) => {
+              normalizedData[type] = normalizedData[type] || [];
+              normalizedData[type].push(item);
+            });
+          } else {
+            normalizedData[item['@type']] = normalizedData[item['@type']] || [];
+            normalizedData[item['@type']].push(item);
+          }
         }
       });
     });

--- a/test/jsonld-parser.spec.js
+++ b/test/jsonld-parser.spec.js
@@ -94,17 +94,29 @@ describe('JSON-LD Parser', () => {
       Movie: [
         {
           '@type': 'Movie',
-          '@location': '35,435',
+          '@location': '35,534',
           name: 'The Matrix',
           director: { '@type': 'Person', name: 'Lana Wachowski' },
+        },
+        {
+          '@type': ['Movie', 'CreativeWork'],
+          '@location': '35,534',
+          name: 'The Matrix Reloaded',
         },
       ],
       Person: [
         {
           '@type': 'Person',
-          '@location': '35,435',
+          '@location': '35,534',
           name: 'Keanu Reeves',
           actor: { '@type': 'Movie', name: 'The Matrix' },
+        },
+      ],
+      CreativeWork: [
+        {
+          '@type': ['Movie', 'CreativeWork'],
+          '@location': '35,534',
+          name: 'The Matrix Reloaded',
         },
       ],
     });
@@ -283,6 +295,64 @@ describe('JSON-LD Parser', () => {
         startOffset: 111,
         endOffset: 256,
       },
+    });
+  });
+
+  it('parses JSON-LD from jsonld6.html with multiple types', async () => {
+    const jsonld6 = await fileReader('test/resources/jsonld6.html');
+    const { jsonld, errors } = extractor.parse(jsonld6);
+    assert.isTrue(errors.length === 0, JSON.stringify(errors));
+    assert.deepEqual(jsonld, {
+      WebPage: [
+        {
+          '@type': ['WebPage', 'FAQPage'],
+          '@id': 'http://www.example.com/faq',
+          url: 'http://www.example.com/faq',
+          '@location': '35,614',
+          name: 'My FAQ page',
+          datePublished: '2023-04-27T10:56:45+01:00',
+          dateModified: '2024-01-09T10:10:03+00:00',
+          primaryImageOfPage: {
+            '@id': 'http://www.example.com/logo.jpg',
+          },
+          inLanguage: 'en-GB',
+          mainEntity: [
+            {
+              '@type': 'Question',
+              name: 'What is a question?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: 'What is an answer?',
+              },
+            },
+          ],
+        },
+      ],
+      FAQPage: [
+        {
+          '@type': ['WebPage', 'FAQPage'],
+          '@id': 'http://www.example.com/faq',
+          '@location': '35,614',
+          url: 'http://www.example.com/faq',
+          name: 'My FAQ page',
+          datePublished: '2023-04-27T10:56:45+01:00',
+          dateModified: '2024-01-09T10:10:03+00:00',
+          primaryImageOfPage: {
+            '@id': 'http://www.example.com/logo.jpg',
+          },
+          inLanguage: 'en-GB',
+          mainEntity: [
+            {
+              '@type': 'Question',
+              name: 'What is a question?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: 'What is an answer?',
+              },
+            },
+          ],
+        },
+      ],
     });
   });
 });

--- a/test/resources/jsonld3.html
+++ b/test/resources/jsonld3.html
@@ -17,6 +17,10 @@
           "@type": "Movie",
           "name": "The Matrix"
         }
+      },
+      {
+        "@type": ["Movie", "CreativeWork"],
+        "name": "The Matrix Reloaded"
       }
     ]
   }

--- a/test/resources/jsonld6.html
+++ b/test/resources/jsonld6.html
@@ -1,0 +1,24 @@
+<script type="application/ld+json">
+  {
+    "@type": ["WebPage", "FAQPage"],
+    "@id": "http://www.example.com/faq",
+    "url": "http://www.example.com/faq",
+    "name": "My FAQ page",
+    "datePublished": "2023-04-27T10:56:45+01:00",
+    "dateModified": "2024-01-09T10:10:03+00:00",
+    "primaryImageOfPage": {
+      "@id": "http://www.example.com/logo.jpg"
+    },
+    "inLanguage": "en-GB",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is a question?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "What is an answer?"
+        }
+      }
+    ]
+  }
+</script>


### PR DESCRIPTION
- Added support for entities with multiple types.
- In the result set, these entities are added for each individual type while their syntax stays unchanged.

## Example
### Input:
```json
{
    "@type": ["WebPage", "FAQPage"],
    "@id": "http://www.example.com/faq",
    "url": "http://www.example.com/faq",
    "name": "My FAQ page",
}
```

### Output:
```json
{
  "jsonld": {
    "WebPage": [
      {
        "@type": ["WebPage", "FAQPage"],
        "@id": "http://www.example.com/faq",
        "url": "http://www.example.com/faq",
        "@location": "35,614",
        "name": "My FAQ page",
      }
    ],
    "FAQPage": [
      {
        "@type": ["WebPage", "FAQPage"],
        "@id": "http://www.example.com/faq",
        "@location": "35,614",
        "url": "http://www.example.com/faq",
        "name": "My FAQ page",
      }
    ]
  }
}
```