### PR TITLE
fix: Return error if parsed JSON is null

### DIFF
--- a/src/parsers/jsonld-parser.js
+++ b/src/parsers/jsonld-parser.js
@@ -34,6 +34,11 @@ export default class JsonldParser {
     try {
       const parsed = JSON.parse(text);
 
+      // Check if parsed is null
+      if (!parsed) {
+        throw new Error('JSON-LD is null');
+      }
+
       // Adjust offsets by removing leading and trailing whitespace
       let startOffset = sourceCodeLocation.startOffset;
       let endOffset = sourceCodeLocation.endOffset;

--- a/test/jsonld-parser.spec.js
+++ b/test/jsonld-parser.spec.js
@@ -355,6 +355,7 @@ describe('JSON-LD Parser', () => {
       ],
     });
   });
+
   it('handles empty JSON-LD', async () => {
     const emptyJsonld = await fileReader('test/resources/jsonld-empty.html');
     const { jsonld, errors } = extractor.parse(emptyJsonld);
@@ -437,6 +438,28 @@ describe('JSON-LD Parser', () => {
       sourceCodeLocation: { startOffset: 35, endOffset: 620 },
       source:
         '{"@graph":[{"@context":"http://schema.org","@type":"Movie","name":"The Matrix","director":{"@type":"Person","name":"Lana Wachowski"}},{"@context":"http://schema.org","@type":"Person","name":"Keanu Reeves","actor":{"@type":"Movie","name":"The Matrix"}},{"@context":"http://schema.org","@type":["Movie","CreativeWork"],"name":"The Matrix Reloaded"}]}',
+    });
+  });
+
+  it('handles null JSON-LD', async () => {
+    // Ensure to not fail early during setting of location or embedSource
+    extractor = new WebAutoExtractor({
+      addLocation: false,
+      embedSource: false,
+    });
+
+    const nullJsonLd = '<script type="application/ld+json">null</script>';
+    const { jsonld, errors } = extractor.parse(nullJsonLd);
+    assert.deepEqual(jsonld, {});
+    assert.equal(errors.length, 1);
+    assert.deepEqual(errors[0], {
+      message: 'Could not parse JSON-LD',
+      format: 'jsonld',
+      source: nullJsonLd.substring(35, 39),
+      sourceCodeLocation: {
+        startOffset: 35,
+        endOffset: 39,
+      },
     });
   });
 });


### PR DESCRIPTION
* Ensure that a `Could not parse JSON-LD` error is returned for cases where the JSON is simply `null`.
* While this is technically a valid JSON object, it's considered invalid in the context of structured data.