### PR TITLE
Handle null JSON-LD graphs

### DIFF
--- a/src/parsers/jsonld-parser.js
+++ b/src/parsers/jsonld-parser.js
@@ -139,6 +139,10 @@ export default class JsonldParser {
     });
   }
 
+  #isRecord(value) {
+    return typeof value === 'object' && value != null;
+  }
+
   #normalizeJsonldData() {
     const normalizedData = {};
     this.jsonldData.forEach((item) => {
@@ -147,7 +151,18 @@ export default class JsonldParser {
       }
 
       item.forEach((item) => {
-        if (item['@graph']) {
+        if (!this.#isRecord(item)) {
+          return;
+        }
+
+        const hasGraph = Object.prototype.hasOwnProperty.call(item, '@graph');
+        const graph = item['@graph'];
+
+        if (hasGraph && graph == null) {
+          return;
+        }
+
+        if (hasGraph) {
           let context = item['@context'];
           let checkContext = true;
 
@@ -156,7 +171,13 @@ export default class JsonldParser {
           } else {
             checkContext = false;
           }
-          item['@graph'].forEach((graphItem) => {
+
+          const graphItems = Array.isArray(graph) ? graph : [graph];
+          graphItems.forEach((graphItem) => {
+            if (!this.#isRecord(graphItem)) {
+              return;
+            }
+
             // Move location and scope down to new root items
             if (item['@location']) {
               graphItem['@location'] = item['@location'];
@@ -192,21 +213,23 @@ export default class JsonldParser {
               normalizedData[graphItem['@type']].push(graphItem);
             }
           });
-        } else {
-          if (!item['@type']) {
-            this.#errorMissingType(item);
-            return;
-          }
 
-          if (Array.isArray(item['@type'])) {
-            item['@type'].forEach((type) => {
-              normalizedData[type] = normalizedData[type] || [];
-              normalizedData[type].push(item);
-            });
-          } else {
-            normalizedData[item['@type']] = normalizedData[item['@type']] || [];
-            normalizedData[item['@type']].push(item);
-          }
+          return;
+        }
+
+        if (!item['@type']) {
+          this.#errorMissingType(item);
+          return;
+        }
+
+        if (Array.isArray(item['@type'])) {
+          item['@type'].forEach((type) => {
+            normalizedData[type] = normalizedData[type] || [];
+            normalizedData[type].push(item);
+          });
+        } else {
+          normalizedData[item['@type']] = normalizedData[item['@type']] || [];
+          normalizedData[item['@type']].push(item);
         }
       });
     });

--- a/test/jsonld-parser.spec.js
+++ b/test/jsonld-parser.spec.js
@@ -441,6 +441,14 @@ describe('JSON-LD Parser', () => {
     });
   });
 
+  it('ignores null @graph containers', async () => {
+    const nullGraphJsonLd =
+      '<script type="application/ld+json">{"@context":"http://schema.org","@graph":null}</script>';
+    const { jsonld, errors } = extractor.parse(nullGraphJsonLd);
+    assert.deepEqual(jsonld, {});
+    assert.equal(errors.length, 0);
+  });
+
   it('handles null JSON-LD', async () => {
     // Ensure to not fail early during setting of location or embedSource
     extractor = new WebAutoExtractor({


### PR DESCRIPTION
## Summary
- Ignore JSON-LD objects whose `@graph` value is `null`
- Preserve existing root-item handling for normal JSON-LD objects
- Add a regression test covering the null `@graph` case

## Verification
- `npx mocha test/jsonld-parser.spec.js`
- `npm test`